### PR TITLE
feat(example): add react example and live-edit usage code

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,18 @@
 {
   "name": "swanky-docs-patterns",
   "description": "Swanky Docs Patterns Demo",
+  "version": "1.0.0",
+  "main": "index.js",
+  "repository": {
+    "url": "git@github.com:swanky-docs/patterns.swanky-docs.org.git",
+    "type": "git"
+  },
+  "author": "Rod Leviton <rod@rodlevtion.com>",
+  "contributors": [
+    "Rod Leviton <rod@rodleviton.com>",
+    "Brett Uglow <u_glow@hotmail.com>"
+  ],
+  "license": "MIT",
   "scripts": {
     "start": "NODE_ENV=development node src/config/start/serve.dev.js",
     "prebuild": "rimraf docs/",
@@ -11,22 +23,19 @@
   },
   "dependencies": {
     "angular": "^1.5.6",
-    "prismjs": "1.6.0"
+    "moment": "2.15.1",
+    "prismjs": "1.6.0",
+    "react": "15.4.2",
+    "react-addons-shallow-compare": "15.4.2",
+    "react-dates": "8.2.1",
+    "react-dom": "15.4.2"
   },
   "devDependencies": {
     "http-server": "0.9.0",
     "npm-run-all": "3.1.2",
     "rimraf": "2.5.4",
-    "swanky": "2.0.2",
-    "swanky-processor-ngdocs": "2.2.3",
-    "webpack": "^2.2.0-rc"
-  },
-  "version": "1.0.0",
-  "main": "index.js",
-  "repository": {
-    "url": "git@github.com:swanky-docs/patterns.swanky-docs.org.git",
-    "type": "git"
-  },
-  "author": "Rod Leviton <rod@rodlevtion.com>",
-  "license": "MIT"
+    "swanky": "2.6.0",
+    "swanky-processor-ngdocs": "2.3.0",
+    "webpack": "^2.2.0"
+  }
 }

--- a/src/config/bootstrap/angular.bootstrap.js
+++ b/src/config/bootstrap/angular.bootstrap.js
@@ -1,21 +1,17 @@
-import angular from 'angular';
+import ngDocsBootstrap from 'swanky-processor-ngdocs/src/bootstrap/angular.bootstrap';
 
-export default (() => {
+// This line MUST contain a static-path (rather than a variable) so that Webpack can determine the list of files to require() at compile-time.
+const modulesToRequire = require.context('../../content/angular-components/', true, /^.*\/index.js$/);
 
-  function requireAll(requireContext) {
-    return requireContext.keys().map(requireContext);
-  }
+// Load all of the Angular modules that you can find then boot the app.
+function requireAll(requireContext) {
+  return requireContext.keys().map(requireContext);
+}
 
-  const modules = requireAll(require.context('../../content/angular-components/', true, /^\.\/.*\/index.js$/));
+const modules = requireAll(modulesToRequire);
 
-  const moduleNames = modules.map((module) => {
-    return module.default ? module.default : module;
-  });
+// Assume module.default is the module name (a string)
+const moduleNameMap = modules.reduce((acc, mod) => Object.assign(acc, {[mod.default]: mod}), {});
 
-  angular.module('app', moduleNames);
+ngDocsBootstrap(moduleNameMap);
 
-  angular.element(document).ready(() => {
-    angular.bootstrap(document, ['app']);
-  });
-
-})();

--- a/src/config/bootstrap/react.bootstrap.js
+++ b/src/config/bootstrap/react.bootstrap.js
@@ -1,0 +1,19 @@
+import reactBootstrap from 'swanky-processor-ngdocs/src/bootstrap/react.bootstrap';
+
+// This line MUST contain a static-path (rather than a variable) so that Webpack can determine the list of files to require() at compile-time.
+const modulesToRequire = require.context('../../content/react-components/', true, /^.*\/index.jsx$/);
+
+// Load all of the React modules that you can find.
+function requireAll(requireContext) {
+  return requireContext.keys().map(requireContext);
+}
+
+// Pass an object-map of moduleNames-to-module-functions: {'DatePicker': function DatePicker() ..., CardInput: function CardInput
+let moduleMap = {};
+
+requireAll(modulesToRequire).forEach(module => {
+  let moduleKeys = Object.keys(module.default);
+moduleKeys.forEach(moduleKey => moduleMap[moduleKey] = module.default[moduleKey]);
+});
+
+reactBootstrap(moduleMap);

--- a/src/content/react-components/datepicker/datepicker.jsx
+++ b/src/content/react-components/datepicker/datepicker.jsx
@@ -1,0 +1,64 @@
+/**
+ * @ngdoc react.component
+ *
+ * @name demo.react:datePicker
+ *
+ * @description
+ * A style-able date picker.
+ *
+ * @requires React
+ *
+ * @param {string=} class The component is designed to be externally styled, but it is possible to apply
+ *   additionally CSS classes to the element
+ *
+ * @usage
+ * ```html
+ * <DatePicker id="uniqueId"/>
+ * ```
+ *
+ * @example
+ * <div>
+ *  <DatePicker id="dp1"/>
+ * </div>
+ *
+ */
+
+import React from 'react';
+import SingleDatePicker from 'react-dates/lib/components/SingleDatePicker';
+import 'react-dates/lib/css/_datepicker.css';
+
+// Copied sections of code from https://github.com/airbnb/react-dates/blob/master/examples/SingleDatePickerWrapper.jsx
+export default class DatePicker extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      focused: props.autoFocus,
+      date: props.initialDate,
+    };
+
+    this.onDateChange = this.onDateChange.bind(this);
+    this.onFocusChange = this.onFocusChange.bind(this);
+  }
+
+  onDateChange(date) {
+    this.setState({ date });
+  }
+
+  onFocusChange({ focused }) {
+    this.setState({ focused });
+  }
+
+  render() {
+    const { focused, date } = this.state;
+
+    return (
+      <SingleDatePicker
+        {...this.props}
+        date={date}
+        focused={focused}
+        onDateChange={this.onDateChange}
+        onFocusChange={this.onFocusChange}
+      />
+    );
+  }
+}

--- a/src/content/react-components/index.jsx
+++ b/src/content/react-components/index.jsx
@@ -1,0 +1,6 @@
+import DatePicker from './datepicker/datepicker.jsx';
+
+// We simply need to reference the files and will render them elsewhere
+export default {
+  DatePicker
+};

--- a/swanky.config.yaml
+++ b/swanky.config.yaml
@@ -35,3 +35,11 @@ sections:
               swanky-processor-ngdocs: {}
           - title: 1.3 Card Accessibility
             src: src/content/components/card/card-accessibility.md
+      - title: DatePicker
+        bootstrap:
+          - src/config/bootstrap/react.bootstrap.js
+        content:
+          - title: DatePicker component
+            src: src/content/react-components/datepicker/datepicker.jsx
+            preprocessor:
+              swanky-processor-ngdocs: {}


### PR DESCRIPTION
Proves that swanky-processor-ngdocs 2.3.0 works.